### PR TITLE
Добавлено обозначение внешних ключей для пользователей и привязка 

### DIFF
--- a/Infrastructure/Data/RoleInitializer.cs
+++ b/Infrastructure/Data/RoleInitializer.cs
@@ -6,6 +6,7 @@ using Core.Entities;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace Infrastructure.Data
 {
@@ -71,6 +72,24 @@ namespace Infrastructure.Data
                     }
                 }
                
+                await context.SaveChangesAsync();
+
+                if (await userManager.FindByEmailAsync(aspUser1.Email) != null)
+                {
+                    var aspUserId = await Task.Run(() => userManager.FindByEmailAsync(aspUser1.Email).Result.Id);
+                    Employee userUpdated1 = await Task.Run(() => context.Employees.FirstOrDefault(e => e.Id == empl1.Id));
+                    userUpdated1.AspUserId = aspUserId;
+                    await Task.Run(() => context.Update<Employee>(userUpdated1));
+                }
+
+                if (await userManager.FindByEmailAsync(aspUser2.Email) != null)
+                {
+                    var aspUserId = await Task.Run(() => userManager.FindByEmailAsync(aspUser2.Email).Result.Id);
+                    Employee userUpdated2 = await Task.Run(() => context.Employees.FirstOrDefault(e => e.Id == empl2.Id));
+                    userUpdated2.AspUserId = aspUserId;
+                    await Task.Run(() => context.Update<Employee>(userUpdated2));
+                }
+
                 await context.SaveChangesAsync();
             }
 


### PR DESCRIPTION
(пользователь - асп_пользователь). Изменения: ранее при создании пользователя с ролью (асп_пользователь), к обычному пользователю не прикреплялся внешний ключ от асп_пользователя, теперь же явным образом обозначена привязка первичного ключа асп_юзера к внешнему ключу юзера.